### PR TITLE
Refactor textbook generator to check redirects

### DIFF
--- a/scripts/generate_book.py
+++ b/scripts/generate_book.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
 
     n_skipped_files = 0
     n_built_files = 0
-    cased_fs = _case_sensitive_fs(BUILD_FOLDER)
+    case_check = _case_sensitive_fs(BUILD_FOLDER) and args.local_build
     print("Convert and copy notebook/md files...")
     for ix_file, page in enumerate(tqdm(list(toc))):
         url_page = page.get('url', None)
@@ -261,17 +261,17 @@ if __name__ == '__main__':
         yaml_fm += ['---']
         # In case pre-existing links are sanitized
         sanitized = url_page.lower().replace('_', '-')
-        if not args.local_build and cased_fs and url_page.lower() == sanitized:
-            raise RuntimeError('Redirect {} clashes with page {} '
-                               'for local build on case-insensitive FS\n'
-                               .format(sanitized, url_page) +
-                               'Consider renaming source page to lower case '
-                               'or building on a case sensitive FS, for example '
-                               'a case-sensitive disk image on Mac')
-        yaml_fm += ['redirect_from:']
-        yaml_fm += ['  - "{}"'.format(sanitized)]
-        if ix_file == 0:
-            yaml_fm += ['  - "/"']
+        if sanitized != url_page:
+            if case_check and url_page.lower() == sanitized:
+                raise RuntimeError(
+                    'Redirect {} clashes with page {} for local build on '
+                    'case-insensitive FS\n'.format(sanitized, url_page) +
+                    'Rename source page to lower case or build on a case '
+                    'sensitive FS, e.g. case-sensitive disk image on Mac')
+            yaml_fm += ['redirect_from:']
+            yaml_fm += ['  - "{}"'.format(sanitized)]
+            if ix_file == 0:
+                yaml_fm += ['  - "/"']
         if path_url_page.endswith('.ipynb'):
             interact_path = 'content/' + path_url_page.split('content/')[-1]
             yaml_fm += ['interact_link: {}'.format(interact_path)]

--- a/scripts/generate_book.py
+++ b/scripts/generate_book.py
@@ -91,6 +91,8 @@ def _case_sensitive_fs(path):
             with open(fname, 'wt') as fobj:
                 fobj.write('text')
         written = glob(root + '*')
+    except Exception:
+        written = []
     finally:
         for fname in written:
             os.unlink(fname)

--- a/scripts/generate_book.py
+++ b/scripts/generate_book.py
@@ -83,7 +83,11 @@ def _case_sensitive_fs(path):
 
     Checks this by attempting to write two files, one w/ upper case, one
     with lower. If after this only one file exists, the system is case-insensitive.
+
+    Makes directory `path` if it does not exist.
     """
+    if not op.exists(path):
+        os.makedirs(path)
     root = op.join(path, uuid4().hex)
     fnames = [root + suffix for suffix in 'aA']
     try:
@@ -91,8 +95,6 @@ def _case_sensitive_fs(path):
             with open(fname, 'wt') as fobj:
                 fobj.write('text')
         written = glob(root + '*')
-    except Exception:
-        written = []
     finally:
         for fname in written:
             os.unlink(fname)

--- a/scripts/tests/test_build.py
+++ b/scripts/tests/test_build.py
@@ -31,9 +31,10 @@ curdir = op.dirname(op.abspath(__file__))
 if op.isdir(op.join(curdir, 'site', '_build')):
     sh.rmtree(op.join(curdir, 'site', '_build'))
 
+print("Building site for test suite...")
 cmd = ["python", op.join(curdir, "..", "generate_book.py"),
        "--site-root", op.join(curdir, "site"), "--path-template", op.join(curdir, "..", "templates", "jekyllmd.tpl")]
-out = subprocess.call(cmd)
+out = subprocess.check_call(cmd)
 
 ####################################################
 # Check outputs

--- a/scripts/tests/test_license.py
+++ b/scripts/tests/test_license.py
@@ -10,6 +10,9 @@ curdir = op.dirname(op.abspath(__file__))
 
 def test_license():
     # Not yes/no answers should error
+    if op.exists(op.join(curdir, "site", "content", "LICENSE.md")):
+        os.remove(op.join(curdir, "site", "content", "LICENSE.md"))
+
     cmd_error = ["python", op.join(curdir, "..", "license.py"),
                 "--path", op.join(curdir, "site", "content"), "--use-license", "blah"]
 


### PR DESCRIPTION
On a case insensitive file-system, the redirect pages could write over
the originals, changing the case of file name, and breaking the links on
a static site.  This wasn't obvious serving locally on my Mac, because
the server is also working on a case-insensitive filesystem and
therefore fetches 'numbers.html' when asked for 'Numbers.html'.  But,
when built and pushed up to - say - Github - with a case-sensitive
filesystem, the breakage appears.