### PR TITLE
Split requirements into build and run

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,7 @@
+# Requirements to build site
+bs4
+tqdm
+numpy
+pyyaml
+nbformat
+nbclean

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-# Textbook
-bs4
-tqdm
-numpy
-pyyaml
-nbformat
-nbclean
-
 # Requirements for the demo notebooks
+# Useful for MyBinder configuration
 pandas
 numpy
 datascience


### PR DESCRIPTION
No need for build requirements when initializing Docker containers for
notebooks.