### PR TITLE
adding mini module and yaml splitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# The Jupyter Book Changelog
+
+Below is a rough list of new features, broken down by Jupyter Book version.
+
+## v0.2.1 - Beta 2.1
+
+- Tests added to the Jupyter Book
+- Utility scripts are now a mini python module
+- Rearranging the location of the build folder and derivative files in this folder
+- Default license picker ([#48](https://github.com/choldgraf/jupyter-book/pull/48))
+- YAML front-matter is now retained by default ([#53](https://github.com/choldgraf/jupyter-book/pull/53))
+
+## v0.2 - Beta 2
+
+- Re-built the backend to Jupyter Book to use a simpler theme
+- Niftier javascript features for faster page loading
+- Improvements to CSS for math and text display
+
+## v0.1 - Beta 1
+
+First Jupyter Book proof-of-concept.

--- a/content/guide/07_advanced.md
+++ b/content/guide/07_advanced.md
@@ -1,6 +1,16 @@
 This page contains more advanced and complete information about the
 [`jupyter-book` repository](https://github.com/choldgraf/jupyter-book). See the sections below.
 
+## Retain custom YAML front-matter in your files
+
+Jupyter book will check your files for YAML front-matter and will **append**
+any newly-generated YAML to the built files for the page. This means you
+can provide your own custom YAML to files (which may be useful if you'd like
+to modify this site's HTML).
+
+Be careful not to add YAML with the same key names as the auto-generated YAML, as
+this will create duplicated keys in your page's front-matter.
+
 ## Relevant files
 
 There are a few moving parts associated with Jupyter Books, and this

--- a/scripts/generate_book.py
+++ b/scripts/generate_book.py
@@ -1,17 +1,23 @@
 from subprocess import check_call
 import os
 import os.path as op
+import sys
 import shutil as sh
 import yaml
 from nbclean import NotebookCleaner
-import nbformat as nbf
 from tqdm import tqdm
 import numpy as np
 from glob import glob
 import argparse
-import string
+
 DESCRIPTION = ("Convert a collection of Jupyter Notebooks into Jekyll "
                "markdown suitable for a course textbook.")
+
+# Add path to our utility functions
+this_folder = op.dirname(op.abspath(__file__))
+sys.path.append(op.join(this_folder, 'scripts'))
+from jupyterbook.utils import (_split_yaml, _check_url_page, _prepare_toc,
+                               _prepare_url, _clean_notebook_cells, _error)
 
 parser = argparse.ArgumentParser(description=DESCRIPTION)
 parser.add_argument("--site-root", default=None, help="Path to the root of the textbook repository.")
@@ -25,64 +31,6 @@ parser.set_defaults(overwrite=False, execute=False)
 # Defaults
 BUILD_FOLDER_NAME = "_build"
 SUPPORTED_FILE_SUFFIXES = ['.ipynb', '.md']
-ALLOWED_CHARACTERS = string.ascii_letters + '-_/.' + string.digits
-
-def _check_url_page(url_page):
-    """Check that the page URL matches certain conditions."""
-    if not all(ii in ALLOWED_CHARACTERS for ii in url_page):
-        raise ValueError("Found unsupported character in filename: {}".format(url_page))
-    if '.' in os.path.splitext(url_page)[-1]:
-        raise _error("A toc.yml entry links to a file directly. You should strip the file suffix.\n"
-                        "Please change {} to {}".format(url_page, os.path.splitext(url_page)[0]))
-    if any(url_page.startswith(ii) for ii in [CONTENT_FOLDER_NAME, os.sep+CONTENT_FOLDER_NAME]):
-        raise ValueError("It looks like you have a page URL that starts with your content folder's name."
-                            "page URLs should be *relative* to the content folder. Here is the page URL: {}".format(url_page))
-    
-def _prepare_toc(toc):
-    """Prepare the TOC for processing."""
-    # Drop toc items w/o links
-    toc = [ii for ii in toc if ii.get('url', None) is not None]
-    # Un-nest the TOC so it's a flat list
-    new_toc = []
-    for ii in toc:
-        sections = ii.pop('sections', None)
-        new_toc.append(ii)
-        if sections is None:
-            continue
-        for jj in sections:
-            subsections = jj.pop('subsections', None)
-            new_toc.append(jj)
-            if subsections is None:
-                continue
-            for kk in subsections:
-                new_toc.append(kk)
-    return new_toc
-
-
-def _prepare_url(url):
-    """Prep the formatting for a url."""
-    # Strip suffixes and prefixes of the URL
-    if not url.startswith('/'):
-        url = '/' + url
-
-    # Standardize the quotes character
-    url = url.replace('"', "'")
-    return url
-
-
-def _clean_notebook_cells(path_ntbk):
-    """Clean up cell text of an nbformat NotebookNode."""
-    ntbk = nbf.read(path_ntbk, nbf.NO_CONVERT)
-    # Remove '#' from the end of markdown headers
-    for cell in ntbk.cells:
-        if cell.cell_type == "markdown":
-            cell_lines = cell.source.split('\n')
-            for ii, line in enumerate(cell_lines):
-                if line.startswith('#'):
-                    cell_lines[ii] = line.rstrip('#').rstrip()
-            cell.source = '\n'.join(cell_lines)
-    nbf.write(ntbk, path_ntbk)
-
 
 def _clean_lines(lines, filepath):
     """Replace images with jekyll image root and add escape chars as needed."""
@@ -126,9 +74,6 @@ def _copy_non_content_files():
             os.makedirs(op.dirname(new_path))
         sh.copy2(ifile, new_path)
 
-def _error(msg):
-    msg = '\n\n==========\n{}\n==========\n'.format(msg)
-    raise ValueError(msg)
 
 
 if __name__ == '__main__':
@@ -179,7 +124,7 @@ if __name__ == '__main__':
         title = page.get('title', None)
 
         # Make sure URLs (file paths) have correct structure
-        _check_url_page(url_page)
+        _check_url_page(url_page, CONTENT_FOLDER_NAME)
 
         ###############################################################################
         # Create path to old/new file and create directory
@@ -282,6 +227,9 @@ if __name__ == '__main__':
             lines = ff.readlines()
         lines = _clean_lines(lines, path_new_file)
 
+        # Split off original yaml
+        yaml_orig, lines = _split_yaml(lines)
+
         # Front-matter YAML
         yaml_fm = []
         yaml_fm += ['---']
@@ -299,6 +247,9 @@ if __name__ == '__main__':
         yaml_fm += ['next_page:']
         yaml_fm += ['  url: {}'.format(url_next_page)]
         yaml_fm += ["  title: '{}'".format(next_file_title)]
+
+        # Add back any original YaML, and end markers
+        yaml_fm += yaml_orig
         yaml_fm += ['comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /{}***"'.format(CONTENT_FOLDER_NAME)]
         yaml_fm += ['---']
         yaml_fm = [ii + '\n' for ii in yaml_fm]

--- a/scripts/jupyterbook/utils.py
+++ b/scripts/jupyterbook/utils.py
@@ -1,0 +1,86 @@
+"""Utility functions for Jupyter Book.
+
+This is a mini-module to make testing easier."""
+
+import string
+import nbformat as nbf
+import os
+
+ALLOWED_CHARACTERS = string.ascii_letters + '-_/.' + string.digits
+
+
+def _split_yaml(lines):
+    yaml0 = None
+    for ii, iline in enumerate(lines):
+        iline = iline.strip()
+        if yaml0 is None:
+            if iline == '---':
+                yaml0 = ii
+            elif iline:
+                break
+        elif iline == '---':
+            return lines[yaml0 + 1:ii], lines[ii + 1:]
+    return [], lines
+
+
+def _check_url_page(url_page, content_folder_name):
+    """Check that the page URL matches certain conditions."""
+    if not all(ii in ALLOWED_CHARACTERS for ii in url_page):
+        raise ValueError("Found unsupported character in filename: {}".format(url_page))
+    if '.' in os.path.splitext(url_page)[-1]:
+        raise _error("A toc.yml entry links to a file directly. You should strip the file suffix.\n"
+                        "Please change {} to {}".format(url_page, os.path.splitext(url_page)[0]))
+    if any(url_page.startswith(ii) for ii in [content_folder_name, os.sep+content_folder_name]):
+        raise ValueError("It looks like you have a page URL that starts with your content folder's name."
+                            "page URLs should be *relative* to the content folder. Here is the page URL: {}".format(url_page))
+    
+def _prepare_toc(toc):
+    """Prepare the TOC for processing."""
+    # Drop toc items w/o links
+    toc = [ii for ii in toc if ii.get('url', None) is not None]
+    # Un-nest the TOC so it's a flat list
+    new_toc = []
+    for ii in toc:
+        sections = ii.pop('sections', None)
+        new_toc.append(ii)
+        if sections is None:
+            continue
+        for jj in sections:
+            subsections = jj.pop('subsections', None)
+            new_toc.append(jj)
+            if subsections is None:
+                continue
+            for kk in subsections:
+                new_toc.append(kk)
+    return new_toc
+
+
+def _prepare_url(url):
+    """Prep the formatting for a url."""
+    # Strip suffixes and prefixes of the URL
+    if not url.startswith('/'):
+        url = '/' + url
+
+    # Standardize the quotes character
+    url = url.replace('"', "'")
+    return url
+
+
+def _clean_notebook_cells(path_ntbk):
+    """Clean up cell text of an nbformat NotebookNode."""
+    ntbk = nbf.read(path_ntbk, nbf.NO_CONVERT)
+    # Remove '#' from the end of markdown headers
+    for cell in ntbk.cells:
+        if cell.cell_type == "markdown":
+            cell_lines = cell.source.split('\n')
+            for ii, line in enumerate(cell_lines):
+                if line.startswith('#'):
+                    cell_lines[ii] = line.rstrip('#').rstrip()
+            cell.source = '\n'.join(cell_lines)
+    nbf.write(ntbk, path_ntbk)
+
+
+def _error(msg):
+    msg = '\n\n==========\n{}\n==========\n'.format(msg)
+    raise ValueError(msg)
+

--- a/scripts/tests/site/content/tests/features.md
+++ b/scripts/tests/site/content/tests/features.md
@@ -1,3 +1,7 @@
+---
+yaml_frontmatter: true
+---
+
 # Features
 
 This is a short demonstration textbook to show the general layout / style of textbooks built


### PR DESCRIPTION
This riffs off of (AKA mostly copies) @matthew-brett 's yaml splitter code so that people can put yaml frontmatter at the top of their files if they wish.

Also splits off the code into a little mini-module to make it easier to test the helper scripts

closes #51 