### PR TITLE
adding collapsible code blocks

### DIFF
--- a/_build/features/notebooks.md
+++ b/_build/features/notebooks.md
@@ -50,7 +50,7 @@ For example, here's some sample Matplotlib code:
 
 
 
-{:.input_area}
+{:.input_area }
 ```python
 from matplotlib import rcParams, cycler
 import matplotlib.pyplot as plt
@@ -61,7 +61,7 @@ plt.ion()
 
 
 
-{:.input_area}
+{:.input_area .hidecode}
 ```python
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -175,7 +175,7 @@ depend on an underlying Python kernel to work.
 
 
 
-{:.input_area}
+{:.input_area }
 ```python
 import folium
 ```
@@ -183,7 +183,7 @@ import folium
 
 
 
-{:.input_area}
+{:.input_area }
 ```python
 m = folium.Map(
     location=[45.372, -121.6972],

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,7 @@ textbook_repo_name       : "jupyter-book"  # The name of the repository on the w
 textbook_repo_branch     : "master"  # The branch on which your textbook is hosted.
 use_jupyterlab           : false  # If 'true', interact links will use JupyterLab as the interface
 interact_text            : "Interact"  # The text that interact buttons will contain.
+show_sidebar             : true  # Show the sidebar. Only set to false if your only wish to host a single page.
 
 #######################################################################################
 # Jekyll build settings

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   <body>
     <!-- .js-show-sidebar shows sidebar by default -->
     <div id="js-textbook" class="c-textbook js-show-sidebar">
-      {% include sidebar.html %}
+      {% if site.show_sidebar == true %}{% include sidebar.html %}{% endif %}
       {% include onthispage.html sanitize=true html=content h_min=2 h_max=3 class="toc__menu" %}
 
       <main class="c-textbook__page" tabindex="-1">

--- a/_sass/components/_components.hidecells.scss
+++ b/_sass/components/_components.hidecells.scss
@@ -1,0 +1,14 @@
+a.hidebtn {
+    position: absolute;
+    top: 2px;
+    right: -25px;
+    width: 1em;
+    height: 1em;
+    padding: .3em;
+    font-size: 1.5em;
+}
+
+.hidden {
+    visibility: hidden;
+    height: 20px;
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -109,6 +109,7 @@ $right-sidebar-width: 200px;
 @import 'components/components.page__nav';
 @import 'components/components.sidebar-toggle';
 @import 'components/components.interact-button';
+@import 'components/components.hidecells';
 
 // UTILITIES
 @import 'inuitcss/utilities/utilities.clearfix';

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -7,6 +7,7 @@
  * [4] Keyboard navigation
  * [5] Copy buttons for code blocks
  * [6] Right sidebar scroll highlighting
+ * [7] Add buttons to hide code cells
  */
 
 const togglerId = 'js-sidebar-toggle'
@@ -204,3 +205,52 @@ highlightRightSidebar = function() {
 };
 
 initFunction(highlightRightSidebar);
+
+
+/**
+ * [7] Add buttons to hide code cells
+ */
+const hideCodeButton = id => `<a class="hidebtn o-tooltip--left" data-id="${id}" data-tooltip="hide code cell">[-]</a>`
+
+var toggleCodeCell = function (element) {
+    var id = element.getAttribute('data-id');
+    var codeCell = document.querySelector(`#${id}`);
+    if (codeCell.classList.contains("hidden")) {
+        codeCell.classList.remove('hidden');
+        element.textContent = "[-]"
+        element.setAttribute('data-tooltip', "hide code cell");
+        
+    } else {
+        codeCell.classList.add('hidden');
+        element.textContent = "[+]"
+        element.setAttribute('data-tooltip', "show code cell");
+    }
+}
+
+toggleCodeCellHandler = function (event) {
+    toggleCodeCell(event.target)
+}
+
+var initCodeCellHandler = function (id) {
+    hideLink = document.querySelector(`#${id}`).nextElementSibling;
+    hideLink.addEventListener('click', toggleCodeCellHandler)
+}
+
+initHiddenCells = function () {
+    document.querySelectorAll('div.hidecode pre').forEach(function (item) {
+        toggleCodeCell(item.nextElementSibling);
+    })
+}
+
+addHideButton = function () {
+    document.querySelectorAll('pre').forEach(function (item, index) {
+        const id = codeCellId(index)
+        item.setAttribute('id', id);
+        item.insertAdjacentHTML('afterend', hideCodeButton(id))
+        initCodeCellHandler(id);
+    });
+
+}
+
+initFunction(addHideButton);
+initFunction(initHiddenCells);

--- a/content/features/notebooks.ipynb
+++ b/content/features/notebooks.ipynb
@@ -56,7 +56,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hidecode"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/scripts/templates/jekyllmd.tpl
+++ b/scripts/templates/jekyllmd.tpl
@@ -3,7 +3,7 @@
 <!-- Add class for input area -->
 {% block input %}
 {% if cell.source != '' %}
-{:.input_area}
+{:.input_area {% if 'hidecode' in cell.metadata.tags %}.hidecode{% endif %}}
 ```
 {%- if 'magics_language' in cell.metadata  -%}
     {{ cell.metadata.magics_language}}


### PR DESCRIPTION
This PR adds the basic support for collapsible code blocks on the built site. If you enable it in the configuration, any of the code cells will have a little button to the side that lets you hide the code contents. In addition, if a notebook cell has a `hidecode` tag in it, then by default the code will be hidden in the site (though it can be re-opened by clicking the button).

@emdupre what do you think about this? I'm thinking it might be time to cut a release of jupyter-book, then this can be the first feature in the next version so there's some time to iterate on it, fix the styling, etc.

Here's a demo of what it looks like:

![2018-12-06_23-55-34](https://user-images.githubusercontent.com/1839645/49628553-c0dcf080-f9b2-11e8-835f-29d970be2f6f.gif)
