### PR TITLE
improve codemirror syntax highlighting

### DIFF
--- a/_includes/js/thebelab.html
+++ b/_includes/js/thebelab.html
@@ -34,9 +34,25 @@
             const codeCells = document.querySelectorAll('.input_area pre')
             codeCells.forEach((codeCell, index) => {
                 const id = codeCellId(index)
-                codeCell.setAttribute('data-executable', '')
+                codeCell.setAttribute('data-executable', 'true')
+
+                // Figure out the language it uses and add this too
+                var parentDiv = codeCell.parentElement.parentElement;
+                var arrayLength = parentDiv.classList.length;
+                for (var ii = 0; ii < arrayLength; ii++) {
+                    var parts = parentDiv.classList[ii].split('language-');
+                    if (parts.length === 2) {
+                        // If found, assign dataLanguage and break the loop
+                        var dataLanguage = parts[1];
+                        break;
+                    }
+                }
+                codeCell.setAttribute('data-language', dataLanguage)
+
+                // If the code cell is hidden, remove it
+                codeCell.parentElement.classList.remove('hidden');
             });
-    
+
             // Init thebelab
             thebelab.bootstrap();
     

--- a/_sass/components/_components.textbook__sidebar-right.scss
+++ b/_sass/components/_components.textbook__sidebar-right.scss
@@ -32,7 +32,7 @@ $right-sidebar-center-offset: ($page-max-width - $sidebar-width) / 2 -
 
     @include mq($from: wide) {
         /* [2] */
-        left: 49%;
+        left: 50%;
         transform: translateX($right-sidebar-center-offset);
     }
 }

--- a/content/guide/06_faq.md
+++ b/content/guide/06_faq.md
@@ -84,6 +84,7 @@ git checkout template/master <path-to-file>
 * `_sass` - the SASS defines the styling of the site. You should also just grab the latest version unless you know
   what you're doing.
 * `_includes` and `_layouts`. These are template files, and should be auto-updated.
+* `Gemfile` which lists the Ruby dependencies for the site.
 
 
 ## Why isn't my math showing up properly?


### PR DESCRIPTION
This fixes a bug where syntax wasn't highlighted in codemirror cells w/ thebelab, also makes sure cells are not hidden if thebelab is used